### PR TITLE
fix gs cmd

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,9 +27,11 @@ def upload():
         args = [
             "gs",
             "-dNOPAUSE", "-dBATCH", "-dSAFER",
+            "-dCompatibilityLevel=1.4",
+            "-dPDFSETTINGS=/screen",
             "-sDEVICE=pdfwrite",
             "-sOutputFile=%stdout",
-            "-c", ".setpdfwrite",
+#            "-c", ".setpdfwrite",
             "-f", inputFile
         ]
         proc = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Good job, I changed the gs command, also the setting of -c ".setpdfwrite", because when compressing it erased the pdf data [video](https://drive.google.com/file/d/1SMbDpYSGCSSoseielIqOqrP3vcsSCGJ5/view?usp=sharing), and the -c flag the value is deprecated.
As I read the documentation of [ghostscript](https://ghostscript.com/) as well as some tutorials [Reduce PDF File Size in Linux](https://www.digitalocean.com/community/tutorials/reduce-pdf-file-size-in-linux).
In the end the command I implemented reduces by a small amount.